### PR TITLE
Enable hover effects for quote cards

### DIFF
--- a/main.js
+++ b/main.js
@@ -246,7 +246,7 @@ class ParallaxController {
 // Enhanced hover effects for project cards
 class CardEffects {
     constructor() {
-        this.cards = document.querySelectorAll('.project-card, .contact-card, .skill-category');
+        this.cards = document.querySelectorAll('.project-card, .contact-card, .skill-category, .quote-card');
         this.init();
     }
 

--- a/style.css
+++ b/style.css
@@ -730,6 +730,13 @@ html {
     -webkit-backdrop-filter: blur(20px);
     backdrop-filter: blur(20px);
     animation: quote-float 8s ease-in-out infinite;
+    transition: all 0.3s ease;
+}
+
+.quote-card:hover {
+    transform: translateY(-10px);
+    border-color: var(--accent-purple);
+    box-shadow: 0 20px 40px rgba(139, 92, 246, 0.3);
 }
 
 .quote-icon {


### PR DESCRIPTION
## Summary
- include `.quote-card` in `CardEffects` so quote cards get interactive hover animations
- add hover styles and transitions for `.quote-card` to match other cards

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68946ee351c883209810a40ac7300f14