### PR TITLE
Enhance parallax depth with scroll-based scaling

### DIFF
--- a/main.js
+++ b/main.js
@@ -173,13 +173,16 @@ class ParallaxController {
 
     startParallaxLoop() {
         const animate = () => {
-            // Apply dramatic parallax to layers
+            // Calculate scale factor based on scroll position for depth effect
+            const scaleFactor = 1 + this.scrollY * 0.0005;
+
+            // Apply dramatic parallax and scaling to layers
             this.layers.forEach(layer => {
                 const speed = parseFloat(layer.dataset.speed) || 1;
                 const baseTransform = this.scrollY * speed * 0.5;
                 const mouseTransform = this.mouseX * speed * 20;
-                
-                layer.style.transform = `translateY(${baseTransform}px) translateX(${mouseTransform}px)`;
+
+                layer.style.transform = `translateY(${baseTransform}px) translateX(${mouseTransform}px) scale(${scaleFactor})`;
             });
 
             // Animate neural network connections

--- a/style.css
+++ b/style.css
@@ -23,7 +23,7 @@
     --ghibli-sky: linear-gradient(135deg, #6c5ce7, #a29bfe, #74b9ff, #00cec9);
     
     /* Animation variables */
-    --parallax-speed: 0.5;
+    --parallax-speed: 0.7;
     --float-animation: 6s ease-in-out infinite;
 }
 


### PR DESCRIPTION
## Summary
- add scroll-position scale factor to parallax layers
- tweak parallax speed variable for stronger depth

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68947eafb8e48320be076c4813692f7c