### PR TITLE
feat: add Afro Ghibli theme and Y2K variants

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Corey Alejandro | AI & Data Engineer</title>
+    <link rel="stylesheet" href="themes/afro-ghibli.css">
     <link rel="stylesheet" href="style.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
@@ -76,7 +77,7 @@
                         <a href="#skills" class="nav-link">Skills</a>
                         <a href="#contact" class="nav-link">Connect</a>
                         <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
-                            <span class="theme-icon">🌙</span>
+                            <span class="theme-icon">🌾</span>
                         </button>
                     </div>
                 </div>

--- a/main.js
+++ b/main.js
@@ -420,7 +420,7 @@ class SkillAnimations {
 // Theme Management
 class ThemeManager {
     constructor() {
-        this.currentTheme = localStorage.getItem('theme') || 'y2k';
+        this.currentTheme = localStorage.getItem('theme') || 'afro-ghibli';
         this.themeToggle = document.getElementById('themeToggle');
         this.themeIcon = this.themeToggle?.querySelector('.theme-icon');
         
@@ -441,7 +441,7 @@ class ThemeManager {
     }
 
     toggleTheme() {
-        const themes = ['y2k', 'corey', 'ghibli-aa'];
+        const themes = ['afro-ghibli', 'y2k-dark', 'y2k-light'];
         const currentIndex = themes.indexOf(this.currentTheme);
         const nextIndex = (currentIndex + 1) % themes.length;
         const newTheme = themes[nextIndex];
@@ -450,24 +450,34 @@ class ThemeManager {
 
     applyTheme(theme) {
         this.currentTheme = theme;
-        document.documentElement.setAttribute('data-theme', theme === 'y2k' ? '' : theme);
+        document.documentElement.setAttribute('data-theme', theme === 'afro-ghibli' ? '' : theme);
         localStorage.setItem('theme', theme);
         
         // Update theme icon
         if (this.themeIcon) {
             const icons = {
-                'y2k': '🌙',
-                'corey': '✨',
-                'ghibli-aa': '🌾'
+                'afro-ghibli': '🌾',
+                'y2k-dark': '🌙',
+                'y2k-light': '☀️'
             };
-            this.themeIcon.textContent = icons[theme] || '🌙';
+            this.themeIcon.textContent = icons[theme] || '🌾';
+        }
+
+        // Update toggle label
+        if (this.themeToggle) {
+            const labels = {
+                'afro-ghibli': 'Switch to Y2K dark theme',
+                'y2k-dark': 'Switch to Y2K light theme',
+                'y2k-light': 'Switch to Afro Ghibli theme'
+            };
+            this.themeToggle.setAttribute('aria-label', labels[theme] || 'Toggle theme');
         }
         
         // Update theme name in console
         const themeNames = {
-            'y2k': 'Y2K',
-            'corey': 'Corey\'s Professional',
-            'ghibli-aa': 'African-American Ghibli'
+            'afro-ghibli': 'Afro Ghibli',
+            'y2k-dark': 'Y2K Dark',
+            'y2k-light': 'Y2K Light'
         };
         console.log(`🎨 Switched to ${themeNames[theme]} theme!`);
         

--- a/style.css
+++ b/style.css
@@ -5,90 +5,58 @@
     box-sizing: border-box;
 }
 
-:root {
-    /* Theme Variables - Y2K Theme (Default) */
+/* Theme Variants */
+[data-theme="y2k-dark"] {
     --primary-bg: #0a0a0f;
     --secondary-bg: #1a1a2e;
+    --card-bg: #1a1a2e;
+    --border-color: #30363d;
     --accent-purple: #8b5cf6;
     --accent-blue: #3b82f6;
     --accent-green: #10b981;
     --accent-pink: #ec4899;
+    --accent-red: var(--accent-pink);
+    --accent-blue-gray: var(--accent-blue);
+    --accent-yellow: var(--accent-green);
     --text-primary: #f8fafc;
     --text-secondary: #cbd5e1;
     --text-muted: #64748b;
-    
-    /* Ghibli-inspired gradients */
     --ghibli-sunset: linear-gradient(135deg, #ff6b6b, #feca57, #48dbfb, #ff9ff3);
     --ghibli-forest: linear-gradient(135deg, #00b894, #00cec9, #74b9ff, #a29bfe);
     --ghibli-sky: linear-gradient(135deg, #6c5ce7, #a29bfe, #74b9ff, #00cec9);
-    
-    /* Animation variables */
     --parallax-speed: 0.7;
     --float-animation: 6s ease-in-out infinite;
 }
 
-/* Corey's Theme */
-[data-theme="corey"] {
-    --primary-bg: #0d1117;
-    --secondary-bg: #161b22;
-    --card-bg: #161b22;
-    --border-color: #30363d;
-    --text-primary: #c9d1d9;
-    --text-secondary: #8b949e;
-    --text-muted: #8b949e;
-    
-    /* Corey's Accent Colors */
-    --accent-red: #ed6a5e;
-    --accent-green: #83c67e;
-    --accent-blue-gray: #7f9fa6;
-    --accent-yellow: #e6c07b;
-    --table-highlight: #21262d;
-    
-    /* Corey's Gradients */
-    --ghibli-sunset: linear-gradient(135deg, #ed6a5e, #e6c07b, #83c67e, #7f9fa6);
-    --ghibli-forest: linear-gradient(135deg, #83c67e, #7f9fa6, #ed6a5e, #e6c07b);
-    --ghibli-sky: linear-gradient(135deg, #7f9fa6, #83c67e, #e6c07b, #ed6a5e);
-}
-
-/* African-American Ghibli Theme */
-[data-theme="ghibli-aa"] {
-    --primary-bg: #1a0f1a;
-    --secondary-bg: #2d1b2d;
-    --card-bg: #3a233a;
-    --border-color: #8b4513;
-    --text-primary: #f4e4bc;
-    --text-secondary: #d4af37;
-    --text-muted: #b8860b;
-    
-    /* African-American Ghibli Accent Colors */
-    --accent-red: #8b0000;
-    --accent-green: #228b22;
-    --accent-blue-gray: #4682b4;
-    --accent-yellow: #daa520;
-    --accent-purple: #9370db;
-    --accent-orange: #ff8c00;
-    --table-highlight: #4a2c2a;
-    
-    /* African-American Ghibli Gradients */
-    --ghibli-sunset: linear-gradient(135deg, #8b0000, #daa520, #228b22, #4682b4);
-    --ghibli-forest: linear-gradient(135deg, #228b22, #4682b4, #8b0000, #daa520);
-    --ghibli-sky: linear-gradient(135deg, #4682b4, #228b22, #daa520, #8b0000);
-    
-    /* Special Ghibli-inspired elements */
-    --ghibli-dust: #f4e4bc;
-    --ghibli-earth: #8b4513;
-    --ghibli-fire: #ff4500;
-    --ghibli-water: #4169e1;
-    --ghibli-air: #87ceeb;
+[data-theme="y2k-light"] {
+    --primary-bg: #f8fafc;
+    --secondary-bg: #e2e8f0;
+    --card-bg: #ffffff;
+    --border-color: #cbd5e1;
+    --accent-purple: #7c3aed;
+    --accent-blue: #2563eb;
+    --accent-green: #059669;
+    --accent-pink: #db2777;
+    --accent-red: var(--accent-pink);
+    --accent-blue-gray: var(--accent-blue);
+    --accent-yellow: var(--accent-green);
+    --text-primary: #1f2937;
+    --text-secondary: #4b5563;
+    --text-muted: #64748b;
+    --ghibli-sunset: linear-gradient(135deg, #ff6b6b, #feca57, #48dbfb, #ff9ff3);
+    --ghibli-forest: linear-gradient(135deg, #00b894, #00cec9, #74b9ff, #a29bfe);
+    --ghibli-sky: linear-gradient(135deg, #6c5ce7, #a29bfe, #74b9ff, #00cec9);
+    --parallax-speed: 0.7;
+    --float-animation: 6s ease-in-out infinite;
 }
 
 body {
-    font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+    font-family: var(--font-family);
     background: var(--primary-bg);
     color: var(--text-primary);
     overflow-x: hidden;
     line-height: 1.6;
-    font-size: 16px;
+    font-size: var(--font-size-base);
 }
 
 /* Smooth scrolling for neurodivergent users */
@@ -676,7 +644,7 @@ html {
 
 .cta-button {
     padding: 1rem 2rem;
-    border-radius: 50px;
+    border-radius: var(--radius-button);
     text-decoration: none;
     font-weight: 600;
     transition: all 0.3s ease;
@@ -692,8 +660,8 @@ html {
 
 .cta-button.secondary {
     background: transparent;
-    color: var(--accent-purple);
-    border-color: var(--accent-purple);
+    color: var(--accent-red);
+    border-color: var(--accent-red);
 }
 
 .cta-button:hover {
@@ -706,7 +674,7 @@ html {
 }
 
 .cta-button.secondary:hover {
-    background: var(--accent-purple);
+    background: var(--accent-red);
     color: var(--text-primary);
 }
 
@@ -957,10 +925,10 @@ html {
 
 .contact-card {
     background: var(--card-bg, rgba(26, 26, 46, 0.8));
-    border-radius: 8px;
-    padding: 1.5rem;
+    border-radius: var(--radius-card);
+    padding: var(--padding-card);
     text-align: center;
-    border: 1px solid var(--border-color, rgba(139, 92, 246, 0.2));
+    border: 1px solid var(--border-color);
     -webkit-backdrop-filter: blur(20px);
     backdrop-filter: blur(20px);
     transition: all 0.3s ease;
@@ -968,14 +936,14 @@ html {
 
 .contact-card:hover {
     transform: translateY(-5px);
-    border-color: var(--accent-purple);
-    box-shadow: 0 15px 30px rgba(139, 92, 246, 0.3);
+    border-color: var(--accent-red);
+    box-shadow: 0 15px 30px rgba(237, 106, 94, 0.3);
 }
 
 .contact-icon {
     font-size: 2.5rem;
     margin-bottom: 1rem;
-    color: var(--accent-purple, var(--accent-red));
+    color: var(--accent-red);
 }
 
 .contact-card h3 {

--- a/themes/afro-ghibli.css
+++ b/themes/afro-ghibli.css
@@ -1,0 +1,31 @@
+:root {
+  --primary-bg: #0d1117;
+  --secondary-bg: #161b22;
+  --card-bg: #161b22;
+  --border-color: #30363d;
+  --text-primary: #c9d1d9;
+  --text-secondary: #8b949e;
+  --text-muted: #8b949e;
+  /* Accent colors */
+  --accent-red: #ed6a5e;
+  --accent-green: #83c67e;
+  --accent-blue-gray: #7f9fa6;
+  --accent-yellow: #e6c07b;
+  /* Legacy accent variables */
+  --accent-purple: var(--accent-red);
+  --accent-blue: var(--accent-blue-gray);
+  --accent-pink: var(--accent-yellow);
+  --table-highlight: #21262d;
+  --radius-card: 8px;
+  --radius-button: 6px;
+  --padding-card: 1.5rem;
+  --spacing-section: 24px;
+  --spacing-element: 16px;
+  --padding-table-y: 0.75em;
+  --padding-table-x: 1.25em;
+  --divider-color: #30363d;
+  --font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-size-base: 16px;
+  --parallax-speed: 0.7;
+  --float-animation: 6s ease-in-out infinite;
+}


### PR DESCRIPTION
## Summary
- add Afro Ghibli design tokens and make it the default theme
- move former Y2K root vars into dedicated dark/light theme scopes
- rotate themes with a simplified Afro Ghibli and Y2K toggle

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6894843451a88320b657571df1d6179c